### PR TITLE
Refactoring arguments and result

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,10 @@
+use tiny_keccak::Keccak;
+use hash::H256;
+
+pub fn keccak<T>(input: T) -> H256 where T: AsRef<[u8]> {
+	let mut keccak = Keccak::new_keccak256();
+	let mut res = H256::new();
+	keccak.update(input.as_ref());
+	keccak.finalize(&mut res);
+	res
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub extern crate bigint;
 pub extern crate parity_hash;
 extern crate tiny_keccak;
 
-use core::{slice, ptr, mem};
+use core::ptr;
 use byteorder::{LittleEndian, ByteOrder};
 pub use alloc::boxed::Box;
 pub use alloc::string::String;
@@ -20,10 +20,6 @@ pub use alloc::str;
 pub use alloc::vec::Vec;
 pub use wasm_alloc::WamsAllocator;
 pub use parity_hash as hash;
-use tiny_keccak::Keccak;
-use hash::Address;
-use hash::H256;
-use bigint::U256;
 
 /// Wrapper over storage read/write externs
 /// Storage api is a key-value storage where both key and value are 32 bytes in len
@@ -34,6 +30,15 @@ pub mod logger;
 
 /// Safe wrapper around externalities invokes
 pub mod ext;
+
+/// Wrapper for arguments and result
+mod wrapped;
+
+/// Crypto functions
+mod crypto;
+
+pub use wrapped::{WrappedArgs, WrappedResult, parse_args};
+pub use crypto::keccak;
 
 /// Fixed-size structures
 
@@ -51,12 +56,6 @@ pub fn panic_fmt(fmt: core::fmt::Arguments, _file_line: &(&'static str, u32)) ->
 }
 
 #[lang = "eh_personality"] extern fn eh_personality() {}
-
-/// Safe wrapper for call context
-pub struct CallArgs {
-    context: Box<[u8]>,
-    result: Box<[u8]>,
-}
 
 unsafe fn read_ptr_mut(slc: &[u8]) -> *mut u8 {
 	ptr::null_mut().offset(read_u32(slc) as isize)
@@ -81,96 +80,4 @@ pub fn read_u64(slc: &[u8]) -> u64 {
 
 pub fn write_u64(dst: &mut [u8], val: u64) {
 	LittleEndian::write_u64(dst, val)
-}
-
-pub fn keccak<T>(input: T) -> H256 where T: AsRef<[u8]> {
-	let mut keccak = Keccak::new_keccak256();
-	let mut res = H256::new();
-	keccak.update(input.as_ref());
-	keccak.finalize(&mut res);
-	res
-}
-
-impl CallArgs {
-	pub unsafe fn from_raw(ptr: *mut u8) -> CallArgs {
-		let desc_slice = slice::from_raw_parts(ptr, 4 * 4);
-
-		let context_ptr = read_ptr_mut(&desc_slice[0..4]);
-		let context_len = read_u32(&desc_slice[4..8]) as usize;
-
-		let result_ptr = read_ptr_mut(&desc_slice[8..12]);
-		let result_len = read_u32(&desc_slice[12..16]) as usize;
-
-		CallArgs {
-			context: Box::<[u8]>::from_raw(slice::from_raw_parts_mut(context_ptr, context_len)),
-			result: Box::<[u8]>::from_raw(slice::from_raw_parts_mut(result_ptr, result_len)),
-		}
-	}
-
-	pub fn context(&self) -> &[u8] {
-		&self.context
-	}
-
-	pub fn result_mut(&mut self) -> &mut Box<[u8]> {
-		&mut self.result
-	}
-
-	pub unsafe fn save(self, ptr: *mut u8) {
-		let dst = slice::from_raw_parts_mut(ptr.offset(8), 2 * 4);
-		let context = self.context;
-		let mut result = self.result;
-
-		// context unmodified and memory is managed in calling code
-		mem::forget(context);
-
-		if result.len() > 0 {
-			// result
-			write_ptr(&mut dst[0..4], result.as_mut_ptr());
-			write_u32(&mut dst[4..8], result.len() as u32);
-			// managed in calling code
-			mem::forget(result);
-		}
-	}
-
-	pub fn params<'a> (&'a self) -> ParamsView<'a> {
-		ParamsView::new(self.context())
-	}
-}
-
-pub struct ParamsView<'a> {
-	raw: &'a [u8],
-}
-
-impl<'a> ParamsView<'a> {
-	fn new(raw: &'a [u8]) -> Self {
-		ParamsView { raw: raw }
-	}
-
-	pub fn address(&self) -> Address {
-		let mut addr = [0u8; 20];
-		addr.copy_from_slice(&self.raw[0..20]);
-		Address::from(addr)
-	}
-
-	pub fn sender(&self) -> Address {
-		let mut sender = [0u8; 20];
-		sender.copy_from_slice(&self.raw[20..40]);
-		Address::from(sender)
-	}
-
-	pub fn origin(&self) -> Address {
-		let mut origin = [0u8; 20];
-		origin.copy_from_slice(&self.raw[40..60]);
-		Address::from(origin)
-	}
-
-	pub fn value(&self) -> U256 {
-		let mut value = [0u8; 32];
-		value.copy_from_slice(&self.raw[60..92]);
-		U256::from_big_endian(&value)
-	}
-
-	pub fn args(&self) -> &[u8] {
-		&self.raw[92..]
-	}
 }

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -1,0 +1,65 @@
+use core::{slice, mem, ops};
+use {Vec, read_u32, read_ptr_mut, write_u32, write_ptr};
+
+pub struct WrappedArgs {
+	inner: Vec<u8>,
+}
+
+impl AsRef<[u8]> for WrappedArgs {
+	fn as_ref(&self) -> &[u8] {
+		&self.inner
+	}
+}
+
+impl ops::Deref for WrappedArgs {
+	type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+		&self.inner
+	}
+}
+
+impl WrappedArgs {
+	unsafe fn from_raw(ptr: *mut u8, len: u32) -> Self {
+		WrappedArgs {
+			inner: Vec::from_raw_parts(ptr, len as usize, len as usize),
+		}
+	}
+}
+
+impl Drop for WrappedArgs {
+	fn drop(&mut self) {
+		mem::forget(mem::replace(&mut self.inner, Vec::new()))
+	}
+}
+
+pub struct WrappedResult {
+	inner: *mut u8,
+}
+
+impl WrappedResult {
+	pub fn done(self, val: Vec<u8>) {
+		if val.len() > 0 {
+			let mut dst = unsafe { slice::from_raw_parts_mut(self.inner, 2 * 4) };
+
+			write_ptr(&mut dst[0..4], val.as_ptr() as *mut _);
+			write_u32(&mut dst[4..8], val.len() as u32);
+			// managed in calling code
+			mem::forget(val);
+		}
+	}
+}
+
+pub unsafe fn parse_args(ptr: *mut u8) -> (WrappedArgs, WrappedResult) {
+	let desc_slice = slice::from_raw_parts(ptr, 4 * 4);
+
+	let input_ptr = read_ptr_mut(&desc_slice[0..4]);
+	let input_len = read_u32(&desc_slice[4..8]);
+
+	let result_ptr = ptr.offset(8);
+
+	(
+		WrappedArgs::from_raw(input_ptr, input_len),
+		WrappedResult { inner: result_ptr }
+	)
+}


### PR DESCRIPTION
- no longer strange `CallArgs` structure which is replaced with separated `WrappedArgs` and `WrappedResult`
- no longer need to save anything to return result, `WrappedResult::done` will do the job 
- no longer arguments are expected to have `origin`, `sender`, `value`, `address` - they are retrieved via externs as other blockchain-related data
